### PR TITLE
Remove statcounter code that belongs to another website.

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,24 +327,6 @@
 			<script src="assets/js/util.js"></script>
 			<!--[if lte IE 8]><script src="assets/js/ie/respond.min.js"></script><![endif]-->
 			<script src="assets/js/main.js"></script>
-			<!-- Start of StatCounter Code for Default Guide -->
-			<script type="text/javascript">
-			var sc_project=11450024;
-			var sc_invisible=1;
-			var sc_security="5aa7692e";
-			var sc_https=1;
-			var scJsHost = (("https:" == document.location.protocol) ?
-			"https://secure." : "http://www.");
-			document.write("<sc"+"ript type='text/javascript' src='" +
-			scJsHost+
-			"statcounter.com/counter/counter.js'></"+"script>");
-			</script>
-			<noscript><div class="statcounter"><a title="web analytics"
-			href="http://statcounter.com/" target="_blank"><img
-			class="statcounter"
-			src="//c.statcounter.com/11450024/0/5aa7692e/1/" alt="web
-			analytics"></a></div></noscript>
-			<!-- End of StatCounter Code for Default Guide -->
 	</body>
 </html>
 


### PR DESCRIPTION
Hi there, I noticed that you copied code from our workshop page `https://github.com/dl4physicalsciences/dl4physicalsciences.github.io`, for which I am one of the co-organizers.

The code is open source and it is absolutely fine to derive another website from it. However it would be expected that you do this with proper attribution to me (as you are basing your website on a version I modified) and the original creator of HTML5 UP, AJ, mentioned here: https://github.com/dl4physicalsciences/dl4physicalsciences.github.io/blob/master/README.txt 

In addition to this, this pull request is for the purpose of removing the statcounter code that was left at the bottom of the page source. The code is associated with our workshop website and it interferes with our statistics if present here.

Thank you very much and I wish you success in your workshop in February.